### PR TITLE
Update chainparams.cpp

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -103,7 +103,7 @@ public:
         pchMessageStart[3] = 0xd9;
         vAlertPubKey = ParseHex("04fc9702847840aaf195de8442ebecedf5b095cdbb9bc716bda9110971b28a49e0ead8564ff0db22209e0374782c093bb899692d524e9d6a6956e7c5ecbcd68284");
         nDefaultPort = 8333;
-        nMaxTipAge = 24 * 60 * 60;
+        nMaxTipAge = 0x7fffffff;
         nPruneAfterHeight = 100000;
 
         genesis = CreateGenesisBlock(1556323201, 152049740, 0x1d00ffff, 1, 50 * COIN);


### PR DESCRIPTION
nMaxTipAge это параметр который указывает "максимальную старость" цепочки блока. Если прошло больше указанного времени, то майнинг будет невозможен, клиент переходит в состояние ожидания блоков от других. В нашем случае никто кроме нас не майнит, поэтому данный параметр надо сделать максимальным